### PR TITLE
[update] make exit API visible from usespace tasks

### DIFF
--- a/api/libc/syscall.h
+++ b/api/libc/syscall.h
@@ -110,6 +110,20 @@ e_syscall_ret sys_log (logsize_t size, const char *msg);
 e_syscall_ret sys_yield(void);
 
 /**
+** \brief exiting task
+**
+** The task is exiting. Its ressources are freed. Remember that a task can't be respawned.
+** This means that the exit is definitive.
+**
+** This syscall results in the immediate scheduling of another task and the cleaning of
+** the task ressources. The task kernel context keeps some informations, including that
+** the task has exited.
+**
+** sys_exit can be called from any task context (ISR or main thread context)
+*/
+e_syscall_ret sys_exit(void);
+
+/**
 ** \brief ask for urgent board reset
 **
 ** The task requests an immediate board software reset. This will clean any secret information or data into

--- a/syscall.c
+++ b/syscall.c
@@ -103,6 +103,12 @@ e_syscall_ret sys_yield(void)
     return do_syscall(SVC_YIELD, &args);
 }
 
+e_syscall_ret sys_exit(void)
+{
+    struct gen_syscall_args args = { 0, 0, 0, 0 };
+    return do_syscall(SVC_EXIT, &args);
+}
+
 e_syscall_ret sys_lock(uint32_t action)
 {
     struct gen_syscall_args args = { 0, 0, 0, 0 };


### PR DESCRIPTION
sys_exit() is a supported and official syscall, yet it was not included in the libstd exported headers.
This patch add it.