### PR TITLE
[update] Removed useless #ifdef directives

### DIFF
--- a/api/libc/syscall.h
+++ b/api/libc/syscall.h
@@ -29,9 +29,7 @@
 #include "libc/types.h"
 #include "kernel/src/C/exported/syscalls.h"
 #include "kernel/src/C/exported/devices.h"
-#ifdef CONFIG_KERNEL_DMA_ENABLE
 #include "kernel/src/C/exported/dmas.h"
-#endif
 #include "kernel/src/C/exported/sleep.h"
 
 // FIXME - nothing to do here!
@@ -75,11 +73,9 @@ e_syscall_ret sys_init_INIT_DONE(uint32_t inittype);
 e_syscall_ret sys_cfg_CFG_GPIO_SET(uint32_t cfgtype, uint8_t gpioref, uint8_t value);
 e_syscall_ret sys_cfg_CFG_GPIO_GET(uint32_t cfgtype, uint8_t gpioref, uint8_t *value);
 e_syscall_ret sys_cfg_CFG_GPIO_UNLOCK_EXTI(uint32_t cfgtype, uint8_t gpioref);
-#ifdef CONFIG_KERNEL_DMA_ENABLE
 e_syscall_ret sys_cfg_CFG_DMA_RECONF(uint32_t cfgtype, dma_t*dma, dma_reconf_mask_t mask, int descriptor);
 e_syscall_ret sys_cfg_CFG_DMA_RELOAD(uint32_t cfgtype, int descriptor);
 e_syscall_ret sys_cfg_CFG_DMA_DISABLE(uint32_t cfgtype, int descriptor);
-#endif
 e_syscall_ret sys_cfg_CFG_DEV_MAP(uint32_t cfgtype, uint32_t devid);
 e_syscall_ret sys_cfg_CFG_DEV_UNMAP(uint32_t cfgtype, uint32_t devid);
 e_syscall_ret sys_cfg_CFG_DEV_RELEASE(uint32_t cfgtype, uint32_t devid);

--- a/syscall.c
+++ b/syscall.c
@@ -212,8 +212,6 @@ e_syscall_ret sys_cfg_CFG_GPIO_UNLOCK_EXTI( __attribute__ ((unused)) uint32_t
     return do_syscall(SVC_GPIO_UNLOCK_EXTI, &args);
 }
 
-
-#ifdef CONFIG_KERNEL_DMA_ENABLE
 e_syscall_ret sys_cfg_CFG_DMA_RECONF( __attribute__ ((unused)) uint32_t cfgtype,
                                      dma_t * dma, dma_reconf_mask_t mask,
                                      int descriptor)
@@ -236,7 +234,6 @@ e_syscall_ret sys_cfg_CFG_DMA_DISABLE( __attribute__ ((unused)) uint32_t
     struct gen_syscall_args args = { (uint32_t) descriptor, 0, 0, 0 };
     return do_syscall(SVC_DMA_DISABLE, &args);
 }
-#endif
 
 e_syscall_ret sys_cfg_CFG_DEV_MAP( __attribute__ ((unused)) uint32_t cfgtype,
                                   uint32_t devid)


### PR DESCRIPTION
* #ifdef CONFIG_KERNEL_DMA_ENABLE directive applies on the kernel and there's no need to apply ti to libstd syscalls