### PR TITLE
[bugfix] fix canary support for functions with ASM inline

### DIFF
--- a/arch/cores/armv7-m/m4_syscall.c
+++ b/arch/cores/armv7-m/m4_syscall.c
@@ -35,7 +35,7 @@ int     _main(uint32_t slot);
 #pragma clang optimize off
   /* Well, clang support local stack protection deactivation only since v8 :-/ */
 #if __clang_major__ > 7
-#pragma clang attribute push(__attribute__((no_stack_protector)), apply_to = do_starttask)
+#pragma clang attribute push(__attribute__((no_stack_protector)))
 #endif
 #endif
 
@@ -71,17 +71,6 @@ __IN_SEC_VDSO void __stack_chk_fail(void)
     while (1) {
     };
 }
-
-#if __clang__
-#pragma clang optimize on
-#if __clang_major__ > 7
-#pragma clang attribute pop
-#endif
-#endif
-
-#if __GNUC__
-#pragma GCC pop_options
-#endif
 
 /**
  ** \private
@@ -278,3 +267,15 @@ __IN_SEC_VDSO e_syscall_ret do_syscall(e_svc_type svc, __attribute__ ((unused))
             return SYS_E_INVAL;
     }
 }
+
+#if __clang__
+#pragma clang optimize on
+#if __clang_major__ > 7
+#pragma clang attribute pop
+#endif
+#endif
+
+#if __GNUC__
+#pragma GCC pop_options
+#endif
+


### PR DESCRIPTION
Canaries with recent versions of gcc (>= 8) are not handled by _s_tack_check_fails() when gcc compiles functions with ASM inline in it (typically syscalls backend).

For those specific functions, canaries must be deactivated to avoid canary invalid construction.

INFO: this PR is a cherry-picking of PR #5 which handle this feature *and* allocator hardening in the same time. For this last PR, a clean rebase must first be done now that the new memory handling mechanism has been merged upstream.