### PR TITLE
[update] add portable explicit fallthrough anotation

### DIFF
--- a/api/libc/types.h
+++ b/api/libc/types.h
@@ -51,6 +51,12 @@ typedef enum {secfalse = 0x55aa55aa, sectrue = 0xaa55aa55} secbool;
 #define __out           /* indication for function arguments (Ada like) */
 #define __inout         /* indication for function arguments (Ada like) */
 
+#if defined(__GNUC__) && __GNUC__ > 7
+#define __explicit_fallthrough __attribute__ ((fallthrough));
+#else
+#define __explicit_fallthrough
+#endif
+
 /*
  * This enumerate defines a list of usual errors that arrise in embedded systems, that can
  * be used in all drivers, stacks, libs and application as a unified error handling mechanism


### PR DESCRIPTION
explicit fallthrough support including abstraction for older gcc versions